### PR TITLE
Mnemonic string trim

### DIFF
--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -44,7 +44,7 @@ export function Login() {
     const isValid = RavencoinKey.isMnemonicValid(value);
 
     if (isValid === false) {
-      alert("The does not seem to be 12 valid words for a Ravencoin wallet");
+      alert("Given input does not seem to be 12 valid words for a Ravencoin wallet");
       setMnemonic(value);
       window.location.reload();
     } else {

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FormEvent } from "react";
 
 import RavencoinKey from "@ravenrebels/ravencoin-key";
 
@@ -32,7 +32,7 @@ export function Login() {
 
     return false;
   }
-  function onSubmit(event) {
+  function onSubmit(event: FormEvent) {
     event.preventDefault();
 
     const mnemonicInput = document.getElementById("mnemonic") as HTMLFormElement;

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -1,11 +1,11 @@
-import React, { FormEvent } from "react";
-
 import RavencoinKey from "@ravenrebels/ravencoin-key";
+import React, { FormEvent } from "react";
+import { LightModeToggle } from "./components/LightModeToggle";
+import { setMnemonic } from "./utils";
 
 //For bundler not to optimize/remove RavencoinKey
 console.log("RavencoinKey", !!RavencoinKey);
-import { LightModeToggle } from "./components/LightModeToggle";
-import { getMnemonic, setMnemonic } from "./utils";
+
 export function Login() {
   const [showWords, setShowWords] = React.useState(false);
   const [dialog, setDialog] = React.useState(<></>);

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -35,11 +35,11 @@ export function Login() {
   function onSubmit(event) {
     event.preventDefault();
 
-    const field = document.getElementById("mnemonic") as HTMLFormElement;
-    if (!field) {
+    const mnemonicInput = document.getElementById("mnemonic") as HTMLFormElement;
+    if (!mnemonicInput) {
       return null;
     }
-    const value = field.value;
+    const value = mnemonicInput.value.trim();
 
     const isValid = RavencoinKey.isMnemonicValid(value);
 


### PR DESCRIPTION
**Proposed changes**
- The user input for the mnemonic string is trimmed from spaces at the beginning and the end of the string. This way the string will pass the RavencoinKey.isMnemonicValid conditional and not give a warning to the user.
- When the mnemonic is not valid, an alert text is shown. The alert text is clarified.
- Type for the onSubmit argument (scout).
- VS Code Alt + Shift + O to organize imports (scout).

**Tested**
- Has been tested manually with mnemonic seed with and without space at beginning, space at end, and space at beginning and end.
- After login the wallets seed phrase has been compared to the given seed phrase.
- Tested on testnet.